### PR TITLE
Amend show-when rule for showing unit scoring

### DIFF
--- a/semantics.json
+++ b/semantics.json
@@ -97,20 +97,25 @@
               {
                 "field": "action",
                 "equals": [
-                  "H5P.ImageHotspotQuestion",
                   "H5P.Blanks",
-                  "H5P.SingleChoiceSet",
-                  "H5P.MultiChoice",
-                  "H5P.TrueFalse",
+                  "H5P.Column",
+                  "H5P.CoursePresentation",
+                  "H5P.Crossword",
+                  "H5P.Dictation",
                   "H5P.DragQuestion",
-                  "H5P.Summary",
                   "H5P.DragText",
+                  "H5P.Essay",
+                  "H5P.Flashcards",
+                  "H5P.ImageHotspotQuestion",
+                  "H5P.InteractiveVideo",
                   "H5P.MarkTheWords",
                   "H5P.MemoryGame",
+                  "H5P.MultiChoice",
                   "H5P.QuestionSet",
-                  "H5P.InteractiveVideo",
-                  "H5P.CoursePresentation",
-                  "H5P.Flashcards"
+                  "H5P.SingleChoiceSet",
+                  "H5P.SortParagraphs",
+                  "H5P.Summary",
+                  "H5P.TrueFalse"
                 ]
               }
             ]


### PR DESCRIPTION
When merged in, will amend the list of triggers for the "unit scoring" of the show-when widget, so all subcontents that can emit scores can be given a custom score.